### PR TITLE
Fixed train/predict layer is none issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+checkpoints
+csv_logs
+tb_logs
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/careamics_napari/widgets/algorithm_choice.py
+++ b/src/careamics_napari/widgets/algorithm_choice.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
     myalgo = TrainingSignal()  # type: ignore
 
-    @myalgo.events.name.connect
+    @myalgo.events.algorithm.connect
     def print_algorithm(name: str):
         """Print the selected algorithm."""
         print(f"Selected algorithm: {name}")

--- a/src/careamics_napari/widgets/predict_data_widget.py
+++ b/src/careamics_napari/widgets/predict_data_widget.py
@@ -98,6 +98,9 @@ class PredictDataWidget(QTabWidget):
 
             # connection actions for images
             self.img_pred.changed.connect(self._update_pred_layer)
+            # to cover the case when image was loaded before the plugin
+            if self.img_pred.value is not None:
+                self._update_pred_layer(self.img_pred.value)
 
         else:
             # simply remove the tab

--- a/src/careamics_napari/widgets/train_data_widget.py
+++ b/src/careamics_napari/widgets/train_data_widget.py
@@ -105,6 +105,12 @@ class TrainDataWidget(QTabWidget):
             self.img_train.changed.connect(self._update_train_layer)
             self.img_val.changed.connect(self._update_val_layer)
 
+            # to cover the case when image was loaded before the plugin
+            if self.img_train.value is not None:
+                self._update_train_layer(self.img_train.value)
+            if self.img_val.value is not None:
+                self._update_val_layer(self.img_val.value)
+
             if self.use_target:
                 # get the target layers
                 self.target_train = layer_choice()
@@ -117,6 +123,12 @@ class TrainDataWidget(QTabWidget):
                 # connection actions for targets
                 self.target_train.changed.connect(self._update_train_target_layer)
                 self.target_val.changed.connect(self._update_val_target_layer)
+
+                # to cover the case when image was loaded before the plugin
+                if self.target_train.value is not None:
+                    self._update_train_target_layer(self.target_train.value)
+                if self.target_val.value is not None:
+                    self._update_val_target_layer(self.target_val.value)
 
                 widget_layers.layout().addRow("Train", self.img_train.native)
                 widget_layers.layout().addRow("Val", self.img_val.native)


### PR DESCRIPTION
When the image was loaded in napari before loading the plugin, the `TrainingSignal` and `PredictionSignal` didn't receive the selected layers although the layer is shown in related combo boxes.  
This happens because combo boxes get populated by the current image as their selected value, so the **`changed`** event won't fire.

This PR should fix the mentioned issue (#3 ).