### PR TITLE
fixed clear plot on training reset

### DIFF
--- a/src/careamics_napari/widgets/train_progress_widget.py
+++ b/src/careamics_napari/widgets/train_progress_widget.py
@@ -91,7 +91,7 @@ class TrainProgressWidget(QGroupBox):
             Training state.
         """
         if state == TrainingState.IDLE or state == TrainingState.TRAINING:
-            self.plot.clear()
+            self.plot.clear_plot()
 
     def _update_max_epoch(self: Self, max_epoch: int):
         """Update the maximum number of epochs in the progress bar.


### PR DESCRIPTION
The issue was about calling the `clear` instead of `clear_plot` (#2 ).  
Apparently, there is a `clear` method for widgets as well :)