### PR TITLE
use `superqt.utils.threadworker`

### DIFF
--- a/src/careamics_napari/workers/prediction_worker.py
+++ b/src/careamics_napari/workers/prediction_worker.py
@@ -7,7 +7,7 @@ from threading import Thread
 from typing import Optional, Union
 
 from careamics import CAREamist
-from napari.qt.threading import thread_worker
+from superqt.utils import thread_worker
 
 from careamics_napari.signals import (
     PredictionSignal,

--- a/src/careamics_napari/workers/saving_worker.py
+++ b/src/careamics_napari/workers/saving_worker.py
@@ -4,7 +4,7 @@ import traceback
 from collections.abc import Generator
 
 from careamics import CAREamist
-from napari.qt.threading import thread_worker
+from superqt.utils import thread_worker
 
 from careamics_napari.signals import (
     ExportType,

--- a/src/careamics_napari/workers/training_worker.py
+++ b/src/careamics_napari/workers/training_worker.py
@@ -9,7 +9,7 @@ from typing import Optional
 import napari.utils.notifications as ntf
 from careamics import CAREamist
 from careamics.config.support import SupportedAlgorithm
-from napari.qt.threading import thread_worker
+from superqt.utils import thread_worker
 
 from careamics_napari.careamics_utils import UpdaterCallBack
 from careamics_napari.careamics_utils.configuration import create_configuration


### PR DESCRIPTION
napari's threadworker was moved to superqt.  the remaining `napari.qt.threadworker` only remains as a thin wrapper to add the `progress=` argument, to link into the napari progress system... which you aren't using here.  So this is a plain drop-in replacement