### PR TITLE
Fix: Forces max pred batches to be an int

### DIFF
--- a/src/careamics_napari/careamics_utils/callback.py
+++ b/src/careamics_napari/careamics_utils/callback.py
@@ -158,11 +158,14 @@ class UpdaterCallBack(Callback):
         pl_module : LightningModule
             PyTorch Lightning module.
         """
+        # lightning returns a number of batches per dataloader
+        # careamics currently only supports one
+        n_batches = int(trainer.num_predict_batches[0])
+
         self.prediction_queue.put(
             PredictionUpdate(
                 PredictionUpdateType.MAX_SAMPLES,
-                # lightning returns a number of batches per dataloader
-                trainer.num_predict_batches[0],
+                n_batches,
             )
         )
 

--- a/src/careamics_napari/careamics_utils/callback.py
+++ b/src/careamics_napari/careamics_utils/callback.py
@@ -159,8 +159,12 @@ class UpdaterCallBack(Callback):
             PyTorch Lightning module.
         """
         # lightning returns a number of batches per dataloader
-        # careamics currently only supports one
-        n_batches = int(trainer.num_predict_batches[0])
+        # if data is loading from disk, the IterableDataset length is not defined.
+        n_batches = trainer.num_predict_batches[0]
+        if n_batches == np.inf:
+            n_batches = "?"
+        else:
+            n_batches = int(n_batches)
 
         self.prediction_queue.put(
             PredictionUpdate(

--- a/src/careamics_napari/widgets/prediction_widget.py
+++ b/src/careamics_napari/widgets/prediction_widget.py
@@ -8,7 +8,6 @@ from qtpy.QtWidgets import (
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
-    QLabel,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -25,11 +24,7 @@ from careamics_napari.signals import (
 )
 
 from .predict_data_widget import PredictDataWidget
-from .qt_widgets import (
-    PowerOfTwoSpinBox,
-    create_progressbar,
-    create_int_spinbox
-)
+from .qt_widgets import PowerOfTwoSpinBox, create_int_spinbox, create_progressbar
 
 
 class PredictionWidget(QGroupBox):


### PR DESCRIPTION
Following https://github.com/CAREamics/careamics-napari/issues/24:

Number of prediction batches is used by the callback to set the maximum of the prediction progress bar. However, PyTorch Lightning types it as `int | float`. The error encountered in #24 is probably due to a float being passed on.

This PR casts the result into an int to avoid the issue.

@mese79 can you reproduce and test the solution?


