### PR TITLE
added a stop prediction button

### DIFF
--- a/src/careamics_napari/prediction_plugin.py
+++ b/src/careamics_napari/prediction_plugin.py
@@ -1,5 +1,6 @@
 """CAREamics prediction Qt widget."""
 
+from collections import deque
 from pathlib import Path
 from queue import Queue
 from typing import TYPE_CHECKING, Optional
@@ -218,9 +219,14 @@ class PredictionPlugin(QWidget):
             self.pred_worker.start()
 
         elif state == PredictionState.STOPPED:
-            # self.careamist.stop_prediction()
-            # TODO not existing yet
-            pass
+            # this will cause an exception in careamist.predict
+            # self.careamist.trainer.predict_loop.teardown()
+            # exhaust the data fetcher to stop the prediction
+            deque(self.careamist.trainer.predict_loop._data_fetcher, maxlen=0)
+            self.careamist.trainer.predict_loop.reset()
+            self._prediction_queue.put(
+                PredictionUpdate(PredictionUpdateType.SAMPLE_IDX, -1)
+            )
 
     def _update_from_prediction(self, update: PredictionUpdate) -> None:
         """Update the signal from the prediction worker.

--- a/src/careamics_napari/widgets/prediction_widget.py
+++ b/src/careamics_napari/widgets/prediction_widget.py
@@ -128,8 +128,14 @@ class PredictionWidget(QGroupBox):
         self.predict_button.setMinimumWidth(120)
         self.predict_button.setEnabled(False)
         self.predict_button.setToolTip("Run the trained model on the images")
+        # stop button
+        self.stop_button = QPushButton("Stop", self)
+        self.stop_button.setMinimumWidth(120)
+        self.stop_button.setEnabled(False)
+        self.stop_button.setToolTip("Stop the prediction")
 
         predictions.layout().addWidget(self.predict_button, alignment=Qt.AlignLeft)
+        predictions.layout().addWidget(self.stop_button, alignment=Qt.AlignRight)
 
         # add to the group
         self.layout().addWidget(self.pb_prediction)
@@ -141,6 +147,7 @@ class PredictionWidget(QGroupBox):
         if self.pred_status is not None and self.train_status is not None:
             # what to do when the buttons are clicked
             self.predict_button.clicked.connect(self._predict_button_clicked)
+            self.stop_button.clicked.connect(self._stop_button_clicked)
 
             self.tile_size_xy.valueChanged.connect(self._set_xy_tile_size)
             self.tile_size_z.valueChanged.connect(self._set_z_tile_size)
@@ -257,6 +264,14 @@ class PredictionWidget(QGroupBox):
             ):
                 self.pred_status.state = PredictionState.PREDICTING
                 self.predict_button.setEnabled(False)
+                self.stop_button.setEnabled(True)
+
+    def _stop_button_clicked(self: Self) -> None:
+        """Stop the prediction."""
+        if self.pred_status is not None:
+            if self.pred_status.state == PredictionState.PREDICTING:
+                self.pred_status.state = PredictionState.STOPPED
+                self.stop_button.setEnabled(False)
 
     def _update_button_from_train(self: Self, state: TrainingState) -> None:
         """Update the predict button based on the training state.
@@ -279,7 +294,11 @@ class PredictionWidget(QGroupBox):
         state : PredictionState
             The new state of the prediction plugin.
         """
-        if state == PredictionState.DONE or state == PredictionState.CRASHED:
+        if (
+            state == PredictionState.DONE
+            or state == PredictionState.CRASHED
+            or state == PredictionState.STOPPED
+        ):
             self.predict_button.setEnabled(True)
 
 

--- a/src/careamics_napari/workers/prediction_worker.py
+++ b/src/careamics_napari/workers/prediction_worker.py
@@ -162,26 +162,8 @@ def _predict(
             batch_size=batch_size,
         )
 
-        update_queue.put(PredictionUpdate(PredictionUpdateType.SAMPLE, result))
-
-        # # TODO can we use this to monkey patch the training process?
-        # import time
-        # update_queue.put(
-        #   PredictionUpdate(PredictionUpdateType.MAX_SAMPLES, 1_000 // 10)
-        # )
-        # for i in range(1_000):
-
-        #     # if stopper.stop:
-        #     #     update_queue.put(Update(UpdateType.STATE, TrainingState.STOPPED))
-        #     #     break
-
-        #     if i % 10 == 0:
-        #         update_queue.put(
-        #              PredictionUpdate(PredictionUpdateType.SAMPLE_IDX, i // 10)
-        #         )
-        #         print(i)
-
-        #     time.sleep(0.2)
+        if result is not None and len(result) > 0:
+            update_queue.put(PredictionUpdate(PredictionUpdateType.SAMPLE, result))
 
     except Exception as e:
         traceback.print_exc()

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -78,7 +78,8 @@ for ax in augmentation:
             n_channels=n_channels,
             patch_size=[8, 8, 8] if "Z" in test_axes else [8, 8],
             batch_size=1,
-            num_epochs=1,  
+            num_epochs=1,
+            masked_pixel_percentage=2,
         )
 
         # instantiate a careamist


### PR DESCRIPTION
Now the prediction widget haz a *stop* button 😉
In lightning, prediction happens in a `while` loop by getting the next batch at each iteration ([see here](https://github.com/Lightning-AI/pytorch-lightning/blob/e088694d411790747af1a52a59a20e6efaa1bebd/src/lightning/pytorch/loops/prediction_loop.py#L112)).  
While the `teardown` method is provided by lightning objects to clean up and reset the object, calling it on the `prediction_loop` during the prediction, will raise an exception:
```python
# this will cause an exception in careamist.predict
self.careamist.trainer.predict_loop.teardown()
```
The solution I've found is to exhaust the *dataloader* all the way, as if we reached to the end of prediction and call the `reset` to prepare the `predict_loop` for the next possible prediction request:
```python
# exhaust the data fetcher to stop the prediction
deque(self.careamist.trainer.predict_loop._data_fetcher, maxlen=0)
self.careamist.trainer.predict_loop.reset()
```
This is not a very clean way since I access a private variable, but seems working (for now 😁).

Addresses #18 