### PR TITLE
fixed enabling channel advanced config when C is in axes

### DIFF
--- a/src/careamics_napari/care_plugin.py
+++ b/src/careamics_napari/care_plugin.py
@@ -50,6 +50,7 @@ class CAREPlugin(BasePlugin):
 
     def show_advanced_config(self) -> None:
         """Show advanced configuration."""
+        self.update_config()
         # show window with advanced options
         win = CAREConfigurationWindow(self, self.careamics_config, self.advanced_config)
         win.finished.connect(lambda: print(self.advanced_config, self.careamics_config))

--- a/src/careamics_napari/n2n_plugin.py
+++ b/src/careamics_napari/n2n_plugin.py
@@ -52,6 +52,7 @@ class N2NPlugin(BasePlugin):
 
     def show_advanced_config(self) -> None:
         """Show advanced configuration."""
+        self.update_config()
         # show window with advanced options
         win = N2NConfigurationWindow(self, self.careamics_config, self.advanced_config)
         win.finished.connect(lambda: print(self.advanced_config, self.careamics_config))

--- a/src/careamics_napari/n2v_plugin.py
+++ b/src/careamics_napari/n2v_plugin.py
@@ -52,6 +52,7 @@ class N2VPlugin(BasePlugin):
 
     def show_advanced_config(self) -> None:
         """Show advanced configuration."""
+        self.update_config()
         # show window with advanced options
         win = N2VConfigurationWindow(self, self.careamics_config, self.advanced_config)
         win.finished.connect(lambda: print(self.advanced_config, self.careamics_config))


### PR DESCRIPTION
This enables channel configs in the advanced config widget when `C` is in axes.  
Basically, we needed to update the configs before passing them to the advanced window.